### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/themes/hugo-theme-wiki/layouts/shortcodes/paper.html
+++ b/themes/hugo-theme-wiki/layouts/shortcodes/paper.html
@@ -1,1 +1,1 @@
-<a href="http://dx.doi.org/{{ .Get 1 }}">{{ .Get 0 }}</a>
+<a href="https://doi.org/{{ .Get 1 }}">{{ .Get 0 }}</a>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update that shortcode that generates new DOI links.

Cheers!